### PR TITLE
Support for comments in the httpasswd file

### DIFF
--- a/st2auth_flat_file_backend/flat_file.py
+++ b/st2auth_flat_file_backend/flat_file.py
@@ -23,6 +23,33 @@ __all__ = [
 
 LOG = logging.getLogger(__name__)
 
+COMMENT_MARKER = '**COMMENTIGNORE**'
+
+
+class HttpasswdFileWithComments(HtpasswdFile):
+    """
+    Custom HtpasswdFile implementation which supports comments (lines starting
+    with #).
+    """
+
+    def _load_lines(self, lines):
+        result = super(HttpasswdFileWithComments, self)._load_lines(lines=lines)
+
+        # Filter out comments
+        self._records.pop(COMMENT_MARKER, None)
+        assert COMMENT_MARKER not in self._records
+
+        return result
+
+    def _parse_record(self, record, lineno):
+        if record.startswith('#'):
+            # Comment, add special marker so we can filter it out later
+            return (COMMENT_MARKER, None)
+
+        result = super(HttpasswdFileWithComments, self)._parse_record(record=record,
+                                                                      lineno=lineno)
+        return result
+
 
 class FlatFileAuthenticationBackend(object):
     """
@@ -43,7 +70,7 @@ class FlatFileAuthenticationBackend(object):
         self._file_path = file_path
 
     def authenticate(self, username, password):
-        htpasswd_file = HtpasswdFile(path=self._file_path)
+        htpasswd_file = HttpasswdFileWithComments(path=self._file_path)
         result = htpasswd_file.check_password(username, password)
 
         if result is None:

--- a/tests/fixtures/htpasswd_test
+++ b/tests/fixtures/htpasswd_test
@@ -1,4 +1,6 @@
 test1:$apr1$GfmyDrUT$PZkK7rw7tAIGgK8hdJ5mh/
+# some comment1
 test2:$2y$05$Vhvhbk0SYN3ncn9BSvXEHunzztBWfrwqOpX1D0GhrFvM1TcADpKoO
 test3:{SHA}i7YRj4/Wk1rQh2o740pxfTJwj/0=
+# some comment2
 test4:8TBeGtbfjQ.R2


### PR DESCRIPTION
This pull request adds support for comments in htpasswd file (Apache htpasswd file implementation supports them).

I will also look into submitting this change upstream in the near future.
