### PR TITLE
Add support for httpasswd files with comments

### DIFF
--- a/st2auth_flat_file_backend/flat_file.py
+++ b/st2auth_flat_file_backend/flat_file.py
@@ -23,6 +23,33 @@ __all__ = [
 
 LOG = logging.getLogger(__name__)
 
+COMMENT_MARKER = '**COMMENTIGNORE**'
+
+
+class HttpasswdFileWithComments(HtpasswdFile):
+    """
+    Custom HtpasswdFile implementation which supports comments (lines starting
+    with #).
+    """
+
+    def _load_lines(self, lines):
+        result = super(HttpasswdFileWithComments, self)._load_lines(lines=lines)
+
+        # Filter out comments
+        self._records.pop(COMMENT_MARKER, None)
+        assert COMMENT_MARKER not in self._records
+
+        return result
+
+    def _parse_record(self, record, lineno):
+        if record.startswith('#'):
+            # Comment, add special marker so we can filter it out later
+            return (COMMENT_MARKER, None)
+
+        result = super(HttpasswdFileWithComments, self)._parse_record(record=record,
+                                                                      lineno=lineno)
+        return result
+
 
 class FlatFileAuthenticationBackend(object):
     """
@@ -43,7 +70,7 @@ class FlatFileAuthenticationBackend(object):
         self._file_path = file_path
 
     def authenticate(self, username, password):
-        htpasswd_file = HtpasswdFile(path=self._file_path)
+        htpasswd_file = HttpasswdFileWithComments(path=self._file_path)
         result = htpasswd_file.check_password(username, password)
 
         if result is None:

--- a/tests/fixtures/htpasswd_test
+++ b/tests/fixtures/htpasswd_test
@@ -1,4 +1,6 @@
 test1:$apr1$GfmyDrUT$PZkK7rw7tAIGgK8hdJ5mh/
+# some comment1
 test2:$2y$05$Vhvhbk0SYN3ncn9BSvXEHunzztBWfrwqOpX1D0GhrFvM1TcADpKoO
 test3:{SHA}i7YRj4/Wk1rQh2o740pxfTJwj/0=
+# some comment2
 test4:8TBeGtbfjQ.R2

--- a/tests/fixtures/htpasswd_test_with_comments
+++ b/tests/fixtures/htpasswd_test_with_comments
@@ -1,4 +1,8 @@
+#some comment 0
 test1:$apr1$GfmyDrUT$PZkK7rw7tAIGgK8hdJ5mh/
+# some comment1
 test2:$2y$05$Vhvhbk0SYN3ncn9BSvXEHunzztBWfrwqOpX1D0GhrFvM1TcADpKoO
 test3:{SHA}i7YRj4/Wk1rQh2o740pxfTJwj/0=
+# some comment2
 test4:8TBeGtbfjQ.R2
+# some comment3

--- a/tests/unit/test_flat_file_backend.py
+++ b/tests/unit/test_flat_file_backend.py
@@ -24,7 +24,7 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 class FlatFileAuthenticationBackendTestCase(unittest2.TestCase):
-    def test_authenticate(self):
+    def test_authenticate_httpasswd_file_without_comments(self):
         file_path = os.path.join(BASE_DIR, '../fixtures/htpasswd_test')
         backend = FlatFileAuthenticationBackend(file_path=file_path)
 
@@ -42,6 +42,31 @@ class FlatFileAuthenticationBackendTestCase(unittest2.TestCase):
 
         # Valid password (crypt - insecure)
         self.assertTrue(backend.authenticate(username='test4', password='testpassword'))
+
+    def test_authenticate_httpasswd_file_with_comments(self):
+        file_path = os.path.join(BASE_DIR, '../fixtures/htpasswd_test_with_comments')
+        backend = FlatFileAuthenticationBackend(file_path=file_path)
+
+        # Inexistent user
+        self.assertFalse(backend.authenticate(username='doesntexist', password='bar'))
+
+        # Invalid password
+        self.assertFalse(backend.authenticate(username='test1', password='bar'))
+
+        # Valid password (md5 hash)
+        self.assertTrue(backend.authenticate(username='test1', password='testpassword'))
+
+        # Valid password (sha hash - insecure)
+        self.assertTrue(backend.authenticate(username='test3', password='testpassword'))
+
+        # Valid password (crypt - insecure)
+        self.assertTrue(backend.authenticate(username='test4', password='testpassword'))
+
+    def test_authenticate_httpasswd_file_doesnt_exist(self):
+        file_path = os.path.join(BASE_DIR, '../fixtures/htpasswd_doesnt_exist')
+        backend = FlatFileAuthenticationBackend(file_path=file_path)
+
+        self.assertRaises(IOError, backend.authenticate, username='doesntexist', password='bar')
 
 if __name__ == '__main__':
     sys.exit(unittest2.main())


### PR DESCRIPTION
I made this change a long time ago, but for some reason, I didn't open a PR for it yet.

This pull request adds support for comments in httpasswd files and it's fully backward compatible.

Note: Apache supports # comments in .htaccess files, but Python library implementation we use doesn't support it.