### PR TITLE
Avoid user-not-found timing attacks w/ dummy hash

### DIFF
--- a/st2auth_flat_file_backend/flat_file.py
+++ b/st2auth_flat_file_backend/flat_file.py
@@ -74,10 +74,10 @@ class HtpasswdFile(object):
             self.entries[username] = hash_data
 
     def check_password(self, username, password):
+        encode_local = locale.getpreferredencoding()
+        pw = bytes(password, encoding=encode_local)
         if username in self.entries:
             hash_data = self.entries[username]
-            encode_local = locale.getpreferredencoding()
-            pw = bytes(password, encoding=encode_local)
             if hash_data.startswith("$apr1$"):
                 LOG.warning(
                     "%s uses MD5 algorithm to hash the password."


### PR DESCRIPTION
Now that we have dropped passlib, this reimplements passlib's dummy verify feature to maintain the same security posture.

See: https://github.com/StackStorm/st2-auth-backend-flat-file/pull/14/files/f1b09ea9a12f49c14b6572c15410506e57544672#r2341493677