### PR TITLE
v0.4.1: Fix importing apr1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,0 @@
-[tool.pytest.ini_options]
-pythonpath = [
-  ".",
-  "st2auth_flat_file_backend"
-]

--- a/st2auth_flat_file_backend/__init__.py
+++ b/st2auth_flat_file_backend/__init__.py
@@ -19,4 +19,4 @@ from .flat_file import FlatFileAuthenticationBackend
 
 __all__ = ["FlatFileAuthenticationBackend"]
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/st2auth_flat_file_backend/flat_file.py
+++ b/st2auth_flat_file_backend/flat_file.py
@@ -18,9 +18,10 @@ import locale
 import bcrypt
 import base64
 import hashlib
-import apr1
 import crypt  # deprecated in 3.11 and removed in 3.13.
 from hmac import compare_digest as compare_hash
+
+from . import apr1
 
 # Reference:    https://httpd.apache.org/docs/2.4/misc/password_encryptions.html
 #               https://akkadia.org/drepper/SHA-crypt.txt


### PR DESCRIPTION
The pythonpath changes in pyproject.toml masked the broken import of apr1. The flat_file backend does not seem to work with `v0.4.0` because of this import error. Stevedore just happily skips this bakcend plugin, saying that it is not even available.

You can see some log output from running `tools/config_gen.py` in [pants CI](https://github.com/StackStorm/st2/actions/runs/18115327876/job/51549827573#step:5:315) and in [legacy ci](https://github.com/StackStorm/st2/actions/runs/18115327834/job/51550220604?pr=6356#step:9:35), and in particular these line:
```
2025-09-30 01:09:16,189 DEBUG [-] found extension EntryPoint(name='flat_file', value='st2auth_flat_file_backend.flat_file:FlatFileAuthenticationBackend', group='st2auth.backends.backend')
2025-09-30 01:09:16,192 ERROR [-] Could not load 'flat_file': No module named 'apr1'
Traceback (most recent call last):
  File "/home/runner/.cache/pants/named_caches/pex_root/venvs/1/s/9cffbce3/venv/lib/python3.10/site-packages/stevedore/extension.py", line 206, in _load_plugins
    ext = self._load_one_plugin(ep,
  File "/home/runner/.cache/pants/named_caches/pex_root/venvs/1/s/9cffbce3/venv/lib/python3.10/site-packages/stevedore/extension.py", line 240, in _load_one_plugin
    plugin = ep.load()
  ...
  File "/home/runner/.cache/pants/named_caches/pex_root/venvs/1/s/9cffbce3/venv/lib/python3.10/site-packages/st2auth_flat_file_backend/__init__.py", line 18, in <module>
    from .flat_file import FlatFileAuthenticationBackend
  File "/home/runner/.cache/pants/named_caches/pex_root/venvs/1/s/9cffbce3/venv/lib/python3.10/site-packages/st2auth_flat_file_backend/flat_file.py", line 21, in <module>
    import apr1
ModuleNotFoundError: No module named 'apr1'
```

So, that pythonpath manipulation did not reflect how st2 actually runs the plugins (It does not put the package dir on PYTHONPATH).

I will cut v0.4.1 once this is merged.